### PR TITLE
Add restart command and english locale

### DIFF
--- a/discord/commands/getLog.js
+++ b/discord/commands/getLog.js
@@ -1,73 +1,82 @@
 const args = process.argv.slice(2)
 
-const axios = require('axios')
-const logSymbols = require('log-symbols')
-const { SlashCommand, CommandOptionType } = require('slash-create')
+const axios = require("axios")
+const logSymbols = require("log-symbols")
+const { SlashCommand, CommandOptionType } = require("slash-create")
 
 const config = require(`${args[0]}/mooncord.json`)
-const discordClient = require('../../clients/discordClient')
-const locale = require('../../utils/localeUtil')
-const permission = require('../../utils/permissionUtil')
-const metadata = require('../commands-metadata/get_log.json')
+const discordClient = require("../../clients/discordClient")
+const locale = require("../../utils/localeUtil")
+const permission = require("../../utils/permissionUtil")
+const metadata = require("../commands-metadata/get_log.json")
 
 const messageLocale = locale.commands.get_log
 const syntaxLocale = locale.syntaxlocale.commands.get_log
 
 module.exports = class EditChannelCommand extends SlashCommand {
-    constructor(creator) {
-        console.log('  Load Get Log Command'.commandload)
-        super(creator, {
-            name: syntaxLocale.command,
-            description: messageLocale.description,
-            options: [{
-                choices: metadata.choices,
-                type: CommandOptionType.STRING,
-                name: syntaxLocale.options.log_file.name,
-                description: messageLocale.options.log_file.description,
-                required: true
-            }]
-        })
-        this.filePath = __filename
+  constructor(creator) {
+    console.log("  Load Get Log Command".commandload)
+    super(creator, {
+      name: syntaxLocale.command,
+      description: messageLocale.description,
+      options: [
+        {
+          choices: metadata.choices,
+          type: CommandOptionType.STRING,
+          name: syntaxLocale.options.log_file.name,
+          description: messageLocale.options.log_file.description,
+          required: true,
+        },
+      ],
+    })
+    this.filePath = __filename
+  }
+
+  async run(ctx) {
+    if (!(await permission.hasController(ctx.user))) {
+      return locale.getControllerOnlyError(ctx.user.username)
     }
 
-    async run(ctx) {
-        if (!await permission.hasController(ctx.user, ctx.guildID, discordClient.getClient())) {
-            return locale.getControllerOnlyError(ctx.user.username)
-        }
+    const service = ctx.options[syntaxLocale.options.log_file.name]
 
-        const service = ctx.options[syntaxLocale.options.log_file.name]
+    ctx.defer(false)
 
-        ctx.defer(false)
+    try {
+      const result = await axios.request({
+        responseType: "arraybuffer",
+        url: `${config.connection.moonraker_url}${metadata.files[service]}`,
+        method: "get",
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      })
 
-        axios.request({
-            responseType: 'arraybuffer',
-            url: `${config.connection.moonraker_url}${metadata.files[service]}`,
-            method: 'get',
-            headers: {
-                'Content-Type': 'text/plain',
-            },
-        }).then(async (result) => {
-            await ctx.send({
-                content: messageLocale.answer.retrieved
-                    .replace(/(\${service})/g, `\`${service}\``),
-                file: {
-                    name: `${service}.log`,
-                    file: result.data
-                }
-            })
-        }).catch(async (error) => {
-            await ctx.send(
-                messageLocale.answer.not_found
-                    .replace(/(\${service})/g, `\`${service}\``)) 
-        });
+      await ctx.send({
+        content: messageLocale.answer.retrieved.replace(
+          /(\${service})/g,
+          `\`${service}\``
+        ),
+        file: {
+          name: `${service}.log`,
+          file: result.data,
+        },
+      })
+    } catch {
+      await ctx.send(
+        messageLocale.answer.not_found.replace(
+          /(\${service})/g,
+          `\`${service}\``
+        )
+      )
     }
+  }
 
-    onError(error, ctx) {
-        console.log(logSymbols.error, `Get Log  Command: ${error}`.error)
-        ctx.send(locale.errors.command_failed)
-    }
+  onError(error, ctx) {
+    console.log(logSymbols.error, `Get Log  Command: ${error}`.error)
+    ctx.send(locale.errors.command_failed)
+  }
 
-    onUnload() {
-        return 'okay'
-    }
+  onUnload() {
+    return "okay"
+  }
 }

--- a/discord/commands/restart.js
+++ b/discord/commands/restart.js
@@ -1,0 +1,99 @@
+const Discord = require("discord.js")
+const logSymbols = require("log-symbols")
+const { SlashCommand, CommandOptionType } = require("slash-create")
+
+const discordClient = require("../../clients/discordClient")
+const moonrakerClient = require("../../clients/moonrakerClient")
+const locale = require("../../utils/localeUtil")
+const permission = require("../../utils/permissionUtil")
+
+const messageLocale = locale.commands.restart
+const syntaxLocale = locale.syntaxlocale.commands.restart
+
+module.exports = class RestartCommand extends SlashCommand {
+  constructor(creator) {
+    console.log("  Load Restart Command".commandload)
+    super(creator, {
+      name: syntaxLocale.command,
+      description: messageLocale.description,
+      options: [
+        {
+          type: CommandOptionType.SUB_COMMAND,
+          name: syntaxLocale.options.firmware.name,
+          description: messageLocale.options.firmware.description,
+        },
+        {
+          type: CommandOptionType.SUB_COMMAND,
+          name: syntaxLocale.options.klipper.name,
+          description: messageLocale.options.klipper.description,
+        },
+      ],
+    })
+    this.filePath = __filename
+  }
+
+  async run(ctx) {
+    if (
+      !(await permission.hasAdmin(
+        ctx.user,
+        ctx.guildID,
+        discordClient.getClient()
+      ))
+    ) {
+      return locale.getAdminOnlyError(ctx.user.username)
+    }
+    const subcommand = ctx.subcommands[0]
+
+    const connection = moonrakerClient.getConnection()
+    const id = Math.floor(Math.random() * Number.parseInt("10_000")) + 1
+
+    ctx.defer(false)
+
+    const handler = (message) => {
+      console.log(message)
+      connection.removeListener("message", handler)
+    }
+
+    switch (subcommand) {
+      case "klipper": {
+        connection.send(
+          `{"jsonrpc": "2.0", "method": "printer.restart", "id": ${id}}`
+        )
+        break
+      }
+
+      case "firmware": {
+        connection.send(
+          `{"jsonrpc": "2.0", "method": "printer.firmware_restart", "id": ${id}}`
+        )
+        break
+      }
+
+      default: {
+        // Some error occurred
+        return
+      }
+    }
+
+    connection.on("message", handler)
+
+    const infoEmbed = new Discord.MessageEmbed()
+      .setColor("#0099ff")
+      .setTitle(messageLocale.embed.title)
+
+    ctx.defer(false)
+
+    await ctx.send({
+      embeds: [infoEmbed.toJSON()],
+    })
+  }
+
+  onError(error, ctx) {
+    console.log(logSymbols.error, `Restart Command: ${error}`.error)
+    ctx.send(locale.errors.command_failed)
+  }
+
+  onUnload() {
+    return "okay"
+  }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,384 +1,421 @@
 {
-    "commands": {
-        "admin": {
-            "description": "Manage Admin Role or User.",
-            "command": "admin",
-            "options": {
-                "role": {
-                    "name": "role",
-                    "description": "Modify Role.",
-                    "options": {
-                        "role": {
-                            "name": "role",
-                            "description": "Select a Role."
-                        }
-                    }
-                },
-                "user": {
-                    "name": "user",
-                    "description": "Modify a User.",
-                    "options": {
-                        "user": {
-                            "name": "user",
-                            "description": "Select a User."
-                        }
-                    }
-                }
-            },
-            "answer": {
-                "added": "${mention} is now a Admin, ${username}!",
-                "removed": "${mention} is not longer a Admin, ${username}!"
+  "commands": {
+    "admin": {
+      "answer": {
+        "added": "${mention} is now a Admin, ${username}!",
+        "removed": "${mention} is not longer a Admin, ${username}!"
+      },
+      "command": "admin",
+      "description": "Manage Admin Role or User.",
+      "options": {
+        "role": {
+          "description": "Modify Role.",
+          "name": "role",
+          "options": {
+            "role": {
+              "description": "Select a Role.",
+              "name": "role"
             }
+          }
         },
-        "editchannel": {
-            "description": "Add or Remove broadcast channel.",
-            "command": "editchannel",
-            "options": {
-                "channel": {
-                    "name": "channel",
-                    "description": "Select a Channel to add/remove it as Broadcast channel."
-                } 
-            },
-            "answer": {
-                "not_textchannel": "${channel} is not a Text Channel, ${username}!",
-                "activated": "${channel} is now a Broadcast Channel, ${username}!",
-                "deactivated": "${channel} is not longer a Broadcast Channel, ${username}!"
+        "user": {
+          "description": "Modify a User.",
+          "name": "user",
+          "options": {
+            "user": {
+              "description": "Select a User.",
+              "name": "user"
             }
-        },
-        "emergency_stop": {
-            "description": "Emergency Stop the Printer?",
-            "command": "emergencystop",
-            "answer": {
-                "executed": "Emergency Stop executed, ${username}!"
-            }
-        },
-        "execute": {
-            "description": "Execute a GCode Command.",
-            "command": "execute",
-            "options": {
-                "gcode": {
-                    "name": "gcode",
-                    "description": "GCode that you want to execute."
-                }
-            },
-            "answer": {
-                "success": "Command Executed!",
-                "error": "Error: `${gcode_feedback}`",
-                "unknown": "Unknown GCode Command: `${gcode_feedback}`"
-            }
-        },
-        "fileinfo": {
-            "description": "Shows Informations about a Print File.",
-            "command": "fileinfo",
-            "options": {
-                "file": {
-                    "name": "file",
-                    "description": "Specifies a Print File."
-                }
-            }
-        },
-        "get_log": {
-            "description": "Retrieve a Log.",
-            "command": "getlog",
-            "options": {
-                "log_file": {
-                    "name": "logfile",
-                    "description": "Specifies the Log File."
-                }
-            },
-            "answer": {
-                "retrieved": "Here is the current Log for ${service}",
-                "not_found": "There is currently no Log for ${service}"
-            }
-        },
-        "info": {
-            "description": "Send a Description about me.",
-            "command": "info",
-            "embed": {
-                "title": "Informations",
-                "description": "Version: ${version}\nAuthor: ${author}\nHomepage: ${homepage}"
-            }
-        },
-        "listfiles": {
-            "description": "List all Print Files.",
-            "command": "listfiles",
-            "embed": {
-                "title": "Print Files"
-            }
-        },
-        "loadinfo": {
-            "description": "Get the current Hardware and Software Informations.",
-            "command": "loadinfo",
-            "options": {
-                "component": {
-                    "name": "component",
-                    "description": "Select the component you want to know the information about."
-                }
-            }
-        },
-        "notify": {
-            "description": "Should i DM you with the current print status?",
-            "command": "notifyme",
-            "answer": {
-                "activated": "I will notify you of the print status via DM, ${username}!",
-                "deactivated": "I will no longer notify you of the print status via DM, ${username}!"
-            }
-        },
-        "printjob": {
-            "description": "Control or start a Print Job.",
-            "command": "printjob",
-            "options": {
-                "pause": {
-                    "name": "pause",
-                    "description": "Pause Print Job"
-                },
-                "cancel": {
-                    "name": "cancel",
-                    "description": "Cancel Print Job"
-                },
-                "resume": {
-                    "name": "resume",
-                    "description": "Resume Print Job"
-                },
-                "start": {
-                    "name": "start",
-                    "description": "Start new Print Job",
-                    "options": {
-                        "file": {
-                            "name": "file",
-                            "description": "Select a Print File."
-                        }
-                    }
-                }
-            },
-            "answer": {
-                "file_not_found": "File not Found!",
-                "resume": {
-                    "status_not_valid": "${username} the Print Job isn`t currently Pausing!",
-                    "status_valid": "${username} you resumed the Print Job!",
-                    "status_same": "${username} the Print Job is running!"
-                },
-                "cancel": {
-                    "status_not_valid": "${username} there isn`t currently any active Print Job!",
-                    "status_valid": "${username} you aborted the Print Job!",
-                    "status_same": ""
-                },
-                "pause": {
-                    "status_not_valid": "${username} there isn`t currently any active Print Job!",
-                    "status_valid": "${username} you paused the Print Job!",
-                    "status_same": "${username} the current Print Job is already Paused!"
-                },
-                "abort": "Print Job request aborted, ${username}!",
-                "executed": "Print Job request executed, ${username}!"
-            },
-            "embed": {
-                "title": "Start Print Job?"
-            }
-        },
-        "status": {
-            "description": "Get the current Print Status.",
-            "command": "status"
-        },
-        "temp": {
-            "description": "Get the current Temperatures from Klipper.",
-            "command": "temp",
-            "embed": {
-                "title": "Temperatures",
-                "fields": {
-                    "current_temp": "Current",
-                    "target_temp": "Target",
-                    "current_power": "Power"
-                }
-            }
+          }
         }
+      }
     },
-    "dynamic_commands": {
-        "timelapse": {
-            "description": "Get the latest Timelapse.",
-            "command": "timelapse"
+    "editchannel": {
+      "answer": {
+        "activated": "${channel} is now a Broadcast Channel, ${username}!",
+        "deactivated": "${channel} is not longer a Broadcast Channel, ${username}!",
+        "not_textchannel": "${channel} is not a Text Channel, ${username}!"
+      },
+      "command": "editchannel",
+      "description": "Add or Remove broadcast channel.",
+      "options": {
+        "channel": {
+          "description": "Select a Channel to add/remove it as Broadcast channel.",
+          "name": "channel"
         }
+      }
     },
-    "misc": {
-        "please_wait": "Please Wait!",
-        "wait_related": "Related to ${relation}"
+    "emergency_stop": {
+      "answer": {
+        "executed": "Emergency Stop executed, ${username}!"
+      },
+      "command": "emergencystop",
+      "description": "Emergency Stop the Printer?"
     },
-    "errors": {
-        "admin_only": "You dont have the Permissions, ${username}",
-        "check_console": "Please Check the Console!",
-        "command_failed": "An Error occured!",
-        "command_timeout": "Command execution failed!",
-        "controller_only": "You dont have the Permissions, ${username}",
-        "file_not_found": "File not Found!",
-        "guild_only": "This Command is only aviable on a Guild, ${username}",
-        "no_data": "There was no Data found for ${component}!",
-        "no_files_found": "There are currently no Files!",
-        "no_timelapse": "There is no Timelapse aviable!",
-        "not_ready": "This Command is not ready, ${username}!"
+    "execute": {
+      "answer": {
+        "error": "Error: `${gcode_feedback}`",
+        "success": "Command Executed!",
+        "unknown": "Unknown GCode Command: `${gcode_feedback}`"
+      },
+      "command": "execute",
+      "description": "Execute a GCode Command.",
+      "options": {
+        "gcode": {
+          "description": "GCode that you want to execute.",
+          "name": "gcode"
+        }
+      }
     },
     "fileinfo": {
-        "title": "File Informations",
-        "print_time": "Print Time",
-        "slicer": "Slicer",
-        "slicer_version": "Slicer version",
-        "height": "Height"
-    },
-    "events": {
-        "print_job_start": {
-            "answer":{
-                "abort": "Print Job request aborted, ${username}!",
-                "executed": "Print Job request executed, ${username}!"
-            }
+      "command": "fileinfo",
+      "description": "Shows Informations about a Print File.",
+      "options": {
+        "file": {
+          "description": "Specifies a Print File.",
+          "name": "file"
         }
+      }
+    },
+    "get_log": {
+      "answer": {
+        "not_found": "There is currently no Log for ${service}",
+        "retrieved": "Here is the current Log for ${service}"
+      },
+      "command": "getlog",
+      "description": "Retrieve a Log.",
+      "options": {
+        "log_file": {
+          "description": "Specifies the Log File.",
+          "name": "logfile"
+        }
+      }
+    },
+    "info": {
+      "command": "info",
+      "description": "Send a Description about me.",
+      "embed": {
+        "description": "Version: ${version}\nAuthor: ${author}\nHomepage: ${homepage}",
+        "title": "Informations"
+      }
+    },
+    "listfiles": {
+      "command": "listfiles",
+      "description": "List all Print Files.",
+      "embed": {
+        "title": "Print Files"
+      }
     },
     "loadinfo": {
-        "cpu": {
-            "title": "CPU",
-            "model": "Model",
-            "manufacturer": "Manufacturer",
-            "usage": "Usage",
-            "cores": "Cores",
-            "threads": "Threads",
-            "temperature": "Temp",
-            "frequency": "Freq",
-            "max_frequency": "Max Freq"
-        },
-        "disk": {
-            "title": "Disks",
-            "name": "Disk ${disk_index} Name",
-            "type": "Disk ${disk_index} Type",
-            "model": "Disk ${disk_index} Model",
-            "vendor": "Disk ${disk_index} Vendor",
-            "size": "Disk ${disk_index} Size"
-        },
-        "os": {
-            "title": "OS",
-            "platform": "Platform",
-            "logofile": "Logofile",
-            "distro": "Distro",
-            "release": "Release",
-            "kernel": "Kernel",
-            "arch": "Arch",
-            "hostname": "Hostname"
-        },
-        "partitions": {
-            "title": "Partitions",
-            "name": "Partition ${partition_index} Name",
-            "type": "Partition ${partition_index} Type",
-            "mount": "Partition ${partition_index} Mount",
-            "size": "Partition ${partition_index} Size",
-            "used": "Partition ${partition_index} Used"
-        },
-        "ram": {
-            "title": "Ram",
-            "total": "Total",
-            "used": "Used",
-            "swap_total": "Swap Total",
-            "swap_used": "Swap Used"
-        },
-        "mcu": {
-            "chipset": "Chipset",
-            "version": "Version",
-            "load": "Load",
-            "awake": "Awake",
-            "frequency": "Freq"
+      "command": "loadinfo",
+      "description": "Get the current Hardware and Software Informations.",
+      "options": {
+        "component": {
+          "description": "Select the component you want to know the information about.",
+          "name": "component"
         }
+      }
     },
-    "loadthrottle": {
-        "title": "System Warning",
-        "sentence": "There is currently a System Warning because of ${reason}!",
-        "high_cpu_load": {
-            "name": "High CPU Load",
-            "suggestion": "Please check what causes the High CPU Usage."
+    "notify": {
+      "answer": {
+        "activated": "I will notify you of the print status via DM, ${username}!",
+        "deactivated": "I will no longer notify you of the print status via DM, ${username}!"
+      },
+      "command": "notifyme",
+      "description": "Should i DM you with the current print status?"
+    },
+    "printjob": {
+      "answer": {
+        "abort": "Print Job request aborted, ${username}!",
+        "cancel": {
+          "status_not_valid": "${username} there isn`t currently any active Print Job!",
+          "status_same": "",
+          "status_valid": "${username} you aborted the Print Job!"
         },
-        "high_cpu_temp": {
-            "name": "High CPU Temp",
-            "suggestion": "Please check your cooling Solution."
+        "executed": "Print Job request executed, ${username}!",
+        "file_not_found": "File not Found!",
+        "pause": {
+          "status_not_valid": "${username} there isn`t currently any active Print Job!",
+          "status_same": "${username} the current Print Job is already Paused!",
+          "status_valid": "${username} you paused the Print Job!"
         },
-        "high_ram_usage": {
-            "name": "High Ram Usage",
-            "suggestion": "Please check what causes the High Ram Usage."
-        },
-        "high_partition_usage": {
-            "name": "High Partition Usage",
-            "suggestion": "Remove some Files from ${component_section}."
+        "resume": {
+          "status_not_valid": "${username} the Print Job isn`t currently Pausing!",
+          "status_same": "${username} the Print Job is running!",
+          "status_valid": "${username} you resumed the Print Job!"
         }
+      },
+      "command": "printjob",
+      "description": "Control or start a Print Job.",
+      "embed": {
+        "title": "Start Print Job?"
+      },
+      "options": {
+        "cancel": {
+          "description": "Cancel Print Job",
+          "name": "cancel"
+        },
+        "pause": {
+          "description": "Pause Print Job",
+          "name": "pause"
+        },
+        "resume": {
+          "description": "Resume Print Job",
+          "name": "resume"
+        },
+        "start": {
+          "description": "Start new Print Job",
+          "name": "start",
+          "options": {
+            "file": {
+              "description": "Select a Print File.",
+              "name": "file"
+            }
+          }
+        }
+      }
+    },
+    "restart": {
+      "answer": {
+        "abort": "Print Job request aborted, ${username}!",
+        "cancel": {
+          "status_not_valid": "${username} there isn`t currently any active Print Job!",
+          "status_same": "",
+          "status_valid": "${username} you aborted the Print Job!"
+        },
+        "executed": "Print Job request executed, ${username}!",
+        "file_not_found": "File not Found!",
+        "pause": {
+          "status_not_valid": "${username} there isn`t currently any active Print Job!",
+          "status_same": "${username} the current Print Job is already Paused!",
+          "status_valid": "${username} you paused the Print Job!"
+        },
+        "resume": {
+          "status_not_valid": "${username} the Print Job isn`t currently Pausing!",
+          "status_same": "${username} the Print Job is running!",
+          "status_valid": "${username} you resumed the Print Job!"
+        }
+      },
+      "command": "restart",
+      "description": "Restart Firmware or MCU",
+      "embed": {
+        "title": "Restarted!"
+      },
+      "options": {
+        "firmware": {
+          "description": "Reloads Klipper's Configurations AND Restarts MCU's",
+          "name": "firmware"
+        },
+        "klipper": {
+          "description": "Reloads Klipper's Configuration.",
+          "name": "klipper"
+        }
+      }
     },
     "status": {
-        "disconnected":{
-            "title": "Printer Disconnected!",
-            "activity": "wait for Klipper"
-        },
-        "error":{
-            "title": "A Error occured!",
-            "activity": "wait for User"
-        },
-        "offline":{
-            "title": "Connection Lost!",
-            "activity": "wait for Moonraker"
-        },
-        "shutdown":{
-            "title": "Klipper Shutdown",
-            "activity": "wait for Klipper"
-        },
-        "stop":{
-            "title": "Print stopped",
-            "activity": "Print stop"
-        },
-        "ready":{
-            "title": "Printer Ready",
-            "activity": "for GCODE File..."
-        },
-        "startup":{
-            "title": "Printer starting",
-            "activity": "Printer start"
-        },
-        "start":{
-            "title": "Print started",
-            "activity": "start ${gcode_file}"
-        },
-        "done":{
-            "title": "Print Done",
-            "activity": "Finished Print"
-        },
-        "pause":{
-            "title": "Print Paused",
-            "activity": "take a Break"
-        },
-        "printing":{
-            "title": "Printing",
-            "activity": "Printing: ${value_print_progress}%"
-        },
+      "command": "status",
+      "description": "Get the current Print Status."
+    },
+    "temp": {
+      "command": "temp",
+      "description": "Get the current Temperatures from Klipper.",
+      "embed": {
         "fields": {
-            "print_time": "Print Time",
-            "eta_print_time": "ETA Print Time",
-            "print_progress": "Progress",
-            "print_layers": "Layer"
-        }
-    },
-    "timelapse": {
-        "for_gcode": "Timelapse for ${gcode_file}"
-    },
-    "update": {
-        "title": "System Updates",
-        "system": "System",
-        "packages": "Packages"
-    },
-    "throttle": {
-        "title": "Throttle occured!",
-        "sentence": "The System is currently throttled because of ${reason}!",
-        "reasons": {
-            "under_voltage_detected": {
-                "name": "Under Voltage",
-                "suggestion": "Please check your Power Delivery."
-            },
-            "temperature_limit_active": {
-                "name": "Temperature Throttle",
-                "suggestion": "Please check your cooling Solution."
-            },
-            "frequency_capped": {
-                "name": "Temperature Throttle",
-                "suggestion": "Please check your cooling Solution."
-            }
-        }
+          "current_power": "Power",
+          "current_temp": "Current",
+          "target_temp": "Target"
+        },
+        "title": "Temperatures"
+      }
     }
+  },
+  "dynamic_commands": {
+    "timelapse": {
+      "command": "timelapse",
+      "description": "Get the latest Timelapse."
+    }
+  },
+  "errors": {
+    "admin_only": "You dont have the Permissions, ${username}",
+    "check_console": "Please Check the Console!",
+    "command_failed": "An Error occured!",
+    "command_timeout": "Command execution failed!",
+    "controller_only": "You dont have the Permissions, ${username}",
+    "file_not_found": "File not Found!",
+    "guild_only": "This Command is only aviable on a Guild, ${username}",
+    "no_data": "There was no Data found for ${component}!",
+    "no_files_found": "There are currently no Files!",
+    "no_timelapse": "There is no Timelapse aviable!",
+    "not_ready": "This Command is not ready, ${username}!"
+  },
+  "events": {
+    "print_job_start": {
+      "answer": {
+        "abort": "Print Job request aborted, ${username}!",
+        "executed": "Print Job request executed, ${username}!"
+      }
+    }
+  },
+  "fileinfo": {
+    "height": "Height",
+    "print_time": "Print Time",
+    "slicer": "Slicer",
+    "slicer_version": "Slicer version",
+    "title": "File Informations"
+  },
+  "loadinfo": {
+    "cpu": {
+      "cores": "Cores",
+      "frequency": "Freq",
+      "manufacturer": "Manufacturer",
+      "max_frequency": "Max Freq",
+      "model": "Model",
+      "temperature": "Temp",
+      "threads": "Threads",
+      "title": "CPU",
+      "usage": "Usage"
+    },
+    "disk": {
+      "model": "Disk ${disk_index} Model",
+      "name": "Disk ${disk_index} Name",
+      "size": "Disk ${disk_index} Size",
+      "title": "Disks",
+      "type": "Disk ${disk_index} Type",
+      "vendor": "Disk ${disk_index} Vendor"
+    },
+    "mcu": {
+      "awake": "Awake",
+      "chipset": "Chipset",
+      "frequency": "Freq",
+      "load": "Load",
+      "version": "Version"
+    },
+    "os": {
+      "arch": "Arch",
+      "distro": "Distro",
+      "hostname": "Hostname",
+      "kernel": "Kernel",
+      "logofile": "Logofile",
+      "platform": "Platform",
+      "release": "Release",
+      "title": "OS"
+    },
+    "partitions": {
+      "mount": "Partition ${partition_index} Mount",
+      "name": "Partition ${partition_index} Name",
+      "size": "Partition ${partition_index} Size",
+      "title": "Partitions",
+      "type": "Partition ${partition_index} Type",
+      "used": "Partition ${partition_index} Used"
+    },
+    "ram": {
+      "swap_total": "Swap Total",
+      "swap_used": "Swap Used",
+      "title": "Ram",
+      "total": "Total",
+      "used": "Used"
+    }
+  },
+  "loadthrottle": {
+    "high_cpu_load": {
+      "name": "High CPU Load",
+      "suggestion": "Please check what causes the High CPU Usage."
+    },
+    "high_cpu_temp": {
+      "name": "High CPU Temp",
+      "suggestion": "Please check your cooling Solution."
+    },
+    "high_partition_usage": {
+      "name": "High Partition Usage",
+      "suggestion": "Remove some Files from ${component_section}."
+    },
+    "high_ram_usage": {
+      "name": "High Ram Usage",
+      "suggestion": "Please check what causes the High Ram Usage."
+    },
+    "sentence": "There is currently a System Warning because of ${reason}!",
+    "title": "System Warning"
+  },
+  "misc": {
+    "please_wait": "Please Wait!",
+    "wait_related": "Related to ${relation}"
+  },
+  "status": {
+    "disconnected": {
+      "activity": "wait for Klipper",
+      "title": "Printer Disconnected!"
+    },
+    "done": {
+      "activity": "Finished Print",
+      "title": "Print Done"
+    },
+    "error": {
+      "activity": "wait for User",
+      "title": "A Error occured!"
+    },
+    "fields": {
+      "eta_print_time": "ETA Print Time",
+      "print_layers": "Layer",
+      "print_progress": "Progress",
+      "print_time": "Print Time"
+    },
+    "offline": {
+      "activity": "wait for Moonraker",
+      "title": "Connection Lost!"
+    },
+    "pause": {
+      "activity": "take a Break",
+      "title": "Print Paused"
+    },
+    "printing": {
+      "activity": "Printing: ${value_print_progress}%",
+      "title": "Printing"
+    },
+    "ready": {
+      "activity": "for GCODE File...",
+      "title": "Printer Ready"
+    },
+    "shutdown": {
+      "activity": "wait for Klipper",
+      "title": "Klipper Shutdown"
+    },
+    "start": {
+      "activity": "start ${gcode_file}",
+      "title": "Print started"
+    },
+    "startup": {
+      "activity": "Printer start",
+      "title": "Printer starting"
+    },
+    "stop": {
+      "activity": "Print stop",
+      "title": "Print stopped"
+    }
+  },
+  "throttle": {
+    "reasons": {
+      "frequency_capped": {
+        "name": "Temperature Throttle",
+        "suggestion": "Please check your cooling Solution."
+      },
+      "temperature_limit_active": {
+        "name": "Temperature Throttle",
+        "suggestion": "Please check your cooling Solution."
+      },
+      "under_voltage_detected": {
+        "name": "Under Voltage",
+        "suggestion": "Please check your Power Delivery."
+      }
+    },
+    "sentence": "The System is currently throttled because of ${reason}!",
+    "title": "Throttle occured!"
+  },
+  "timelapse": {
+    "for_gcode": "Timelapse for ${gcode_file}"
+  },
+  "update": {
+    "packages": "Packages",
+    "system": "System",
+    "title": "System Updates"
+  }
 }


### PR DESCRIPTION

Changes:

1. Adds in a `/restart` command that can restart either klipper or firmware. 
2. Adds in the English locale update that includes the `/restart` locale.
3. Cleaned up the async logic in the `getLog` command.