### PR TITLE
Add a Dockerfile to support building containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:16-alpine as builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+FROM node:16-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache tini ffmpeg
+
+# Since dist/ will not contain everything needed to run Mooncord, copy all of /app for now
+COPY --from=builder /app/ /app/
+
+USER node
+
+ENTRYPOINT ["/tini", "--"]
+CMD ["node", "/app/dist/index.js"]


### PR DESCRIPTION
Build process uses a builder container to minimise overhead from layers,
but it's unlikely that this makes a huge difference.

Final container contains ffmpeg and runs the process with tini