### PR TITLE
Move image path to MessageAttachment from MessageEmbed

### DIFF
--- a/websocket-events/gcodeCommands.js
+++ b/websocket-events/gcodeCommands.js
@@ -15,8 +15,8 @@ const event = (message, connection, discordClient, database) => {
     const { params } = messageJson
     if(params[0].startsWith("mooncord.broadcast")) {
       const message = params[0].replace("mooncord.broadcast ", "")
-      const attachment = new Discord.MessageAttachment()
-      const broadcastembed = new Discord.MessageEmbed(path.resolve(__dirname, '../images/notification.png'))
+      const attachment = new Discord.MessageAttachment(path.resolve(__dirname, '../images/notification.png'))
+      const broadcastembed = new Discord.MessageEmbed()
         .setColor('#03f4fc')
         .setTitle('Message')
         .setThumbnail('attachment://notification.png')


### PR DESCRIPTION
Issue: Broadcast messages were failing and crashing the service due to the following error:

```
npm[17657]: /home/pi/mooncord/node_modules/discord.js/src/structures/MessageEmbed.js:78
npm[17657]:     this.color = 'color' in data ? Util.resolveColor(data.color) : null;
npm[17657]:                          ^
npm[17657]: TypeError: Cannot use 'in' operator to search for 'color' in /home/pi/mooncord/images/notification.png
```

Fix: The notification image needs to be passed into MessageAttachment() instead of MessageEmbed().