### PR TITLE
Fix bug with /listfiles

### DIFF
--- a/src/helper/PageHelper.ts
+++ b/src/helper/PageHelper.ts
@@ -30,7 +30,7 @@ export class PageHelper {
         const max = this.configHelper.getEntriesPerPage() - 1
         const rawEntries = []
         for (let i = (page * max) + page;
-             i <= max + (page * max) + page;
+             i <= Math.min(this.data.length - 1, max + (page * max) + page);
              i++) {
             const entry = this.data[i]
             rawEntries.push(entry)
@@ -42,7 +42,7 @@ export class PageHelper {
     }
 
     protected getLastPage() {
-        return Math.floor(this.data.length / this.configHelper.getEntriesPerPage())
+        return Math.ceil(this.data.length / this.configHelper.getEntriesPerPage())
     }
 
     protected getNewPage(pageUp: boolean, currentPage: number) {


### PR DESCRIPTION
There is a bug with `/listfiles` command that causes issues in printers with low number of print files resulting in the `/listfiles` command to hang/crash. The log file outputs:

```
[error] [2022-01-15T04:04:20.261Z] TypeError: Cannot read properties of undefined (reading 'path')
      TypeError: Cannot read properties of undefined (reading 'path')
            at /home/pi/mooncord/dist/index.js:15:280399
            at String.replace (<anonymous>)
            at parsePageData (/home/pi/mooncord/dist/index.js:15:280301)
            at PageHelper.getEntries (/home/pi/mooncord/dist/index.js:15:325937)
            at PageHelper.getPage (/home/pi/mooncord/dist/index.js:15:325659)
            at FileListCommand.execute (/home/pi/mooncord/dist/index.js:15:341033)
            at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

Existing code doesn't seem to account for situations where entities don't fill up the last page. On top of this, it seems to also miscalculate the number of total pages.

This pull request should handle those situations.