### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ COPY --from=builder /app/ /app/
 
 USER node
 
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["node", "/app/dist/index.js"]


### PR DESCRIPTION
Image built based on `Dockerfile` in repo would not bring up properly. Bringing inline with [documentation](https://github.com/krallin/tini#alpine-linux-package).

I suppose that the project could also use an update on the wiki to include using `mooncord` in a container. I may push in something for that later.